### PR TITLE
Added checks for spoofers and minors

### DIFF
--- a/cogs/trainer.py
+++ b/cogs/trainer.py
@@ -155,7 +155,10 @@ class Profiles:
 		except discord.errors.Forbidden:
 			await self.bot.say("Error: I don't have permission to change nicknames. Aborted!")
 		else:
-			approved_mentionable = discord.utils.get(ctx.message.server.roles, name='Trainer')
+			if (opt.title() in ['Minor', 'Child']) and discord.utils.get(ctx.message.server.roles, name='Minor'):
+				approved_mentionable = discord.utils.get(ctx.message.server.roles, name='Minor')
+			else:
+				approved_mentionable = discord.utils.get(ctx.message.server.roles, name='Trainer')
 			team_mentionable = discord.utils.get(ctx.message.server.roles, name=team.title())
 			try:
 				await self.bot.add_roles(mbr, approved_mentionable)

--- a/cogs/trainer.py
+++ b/cogs/trainer.py
@@ -12,6 +12,8 @@ trnr = sqlite3.connect('trainers.db')
 c = trnr.cursor()
 
 def rounddays(x):
+NOT_IN_SYSTEM = "Uh-oh! Looks like you're not registered into the system. Please ask an admin to handle this for you!"
+
 	return int(86500 * round(float(x)/86400))
 
 class Calls:
@@ -36,7 +38,7 @@ class Profiles:
 		diff = int(profile[1])-int(history[1])
 		days = int(rounddays(profile[2]-history[2])/86400)
 		goal = profile[3]
-		goal_cent = ((diff/days)/goal)*100
+		goal_cent = round(((diff/days)/goal)*100,2)
 		return goal_cent		
 		
 	async def profile_card(self, name, channel, goal:str=None):
@@ -90,7 +92,7 @@ class Profiles:
 		oldxp = c.execute('SELECT pogo_name, total_xp, last_updated, goal FROM trainers WHERE discord_id=?', (ctx.message.author.id,)).fetchone()
 		if oldxp:
 			if int(oldxp[1]) > int(xp):
-				await self.bot.say("Error: Specified XP higher than currently set XP. Please use the Total XP at the bottom of your profile.")
+				await self.bot.say("Error: You're trying to set an your XP to a lower value. Please make sure you're using your Total XP at the bottom of your profile.")
 				return
 			c.execute("INSERT INTO xp_history (trainer, xp, time) VALUES (?,?,?)", (oldxp[0], oldxp[1], oldxp[2]))
 			c.execute("UPDATE trainers SET total_xp=?, last_updated=? WHERE discord_id=?", (int(xp), int(time.time()), ctx.message.author.id))
@@ -100,7 +102,7 @@ class Profiles:
 			else:
 				await self.profile_card(oldxp[0], ctx.message.channel)
 		else:
-			await self.bot.say("Please ask a member of staff to add your profile to the system.")
+			await self.bot.say(NOT_IN_SYSTEM)
 			return
 		
 	@commands.command(pass_context=True)
@@ -112,7 +114,7 @@ class Profiles:
 			trnr.commit()
 			await self.profile_card(profile[0], ctx.message.channel)
 		else:
-			await self.bot.say("Please ask a member of staff to add your profile to the system.")
+			await self.bot.say(NOT_IN_SYSTEM)
 			return
 		
 	@commands.command(pass_context=True)
@@ -124,7 +126,7 @@ class Profiles:
 			trnr.commit()
 			await self.bot.say("Your daily XP goal is set to {}.".format(goal))
 		else:
-			await self.bot.say("Please ask a member of staff to add your profile to the system.")
+			await self.bot.say(NOT_IN_SYSTEM)
 			return
 			
 #Mod-commands

--- a/cogs/trainer.py
+++ b/cogs/trainer.py
@@ -2,29 +2,30 @@ import asyncio
 import pytz
 import time
 import datetime
+
+import sqlite3
 import discord
 from cogs.utils import checks
 from discord.ext import commands
-import sqlite3
 
 tz = pytz.timezone('Europe/London')
 trnr = sqlite3.connect('trainers.db')
 c = trnr.cursor()
 
-def rounddays(x):
 NOT_IN_SYSTEM = "Uh-oh! Looks like you're not registered into the system. Please ask an admin to handle this for you!"
 
+def roundDays(x):
 	return int(86500 * round(float(x)/86400))
 
 class Calls:
 
-	def get_name(self, discord):
-		profile = c.execute('SELECT pogo_name FROM trainers WHERE discord_id=?', (discord,)).fetchone()
-		return profile[0]
+	def getName(self, discord):
+		t_pogo, = c.execute('SELECT pogo_name FROM trainers WHERE discord_id=?', (discord,)).fetchone()
+		return t_pogo
 	
-	def get_member(self, pogo):
-		profile = c.execute('SELECT discord_id FROM trainers WHERE pogo_name=?', (pogo,)).fetchone()
-		return profile[0]
+	def getMember(self, pogo):
+		t_discord, = c.execute('SELECT discord_id FROM trainers WHERE pogo_name=?', (pogo,)).fetchone()
+		return t_discord
 
 class Profiles:
 	"""Trainer profile system"""
@@ -32,47 +33,46 @@ class Profiles:
 	def __init__(self, bot):
 		self.bot = bot
 		
-	async def goal_daily(self, discord):
-		profile = c.execute('SELECT pogo_name, total_xp, last_updated, goal FROM trainers WHERE discord_id=?', (discord,)).fetchone()
-		history = c.execute('SELECT trainer, xp, time FROM xp_history WHERE trainer=? AND time<? ORDER BY time DESC', (profile[0], profile[2]-64800)).fetchone()
-		diff = int(profile[1])-int(history[1])
-		days = int(rounddays(profile[2]-history[2])/86400)
-		goal = profile[3]
+	async def goalDaily(self, discord):
+		t_pogo, t_xp, t_time, t_goal = c.execute('SELECT pogo_name, total_xp, last_updated, goal FROM trainers WHERE discord_id=?', (discord,)).fetchone()
+		h_pogo, h_xp, h_time = c.execute('SELECT trainer, xp, time FROM xp_history WHERE trainer=? AND time<? ORDER BY time DESC', (t_pogo, t_time-64800)).fetchone()
+		diff = int(t_xp)-int(h_xp)
+		days = int(roundDays(t_time-h_time)/86400)
+		goal = t_goal
 		goal_cent = round(((diff/days)/goal)*100,2)
 		return goal_cent		
 		
-	async def profile_card(self, name, channel, goal:str=None):
-		trn = c.execute('SELECT pogo_name, total_xp, last_updated, team, discord_id, real_name, spoofer, no_stats FROM trainers WHERE pogo_name=?', (name,)).fetchone()
-		if trn==None:
+	async def profileCard(self, name, channel, goal:str=None):
+		t_pogo, t_xp, t_time, t_team, t_discord, t_name, t_cheat, t_opt_out = c.execute('SELECT pogo_name, total_xp, last_updated, team, discord_id, real_name, spoofer, no_stats FROM trainers WHERE pogo_name=?', (name,)).fetchone()
+		if t_pogo==None:
 			await self.bot.say("Unfortunately, I couldn't find {} in the database. Are you sure you spelt their name right?".format(name))
-		elif trn[7]:
-			await self.bot.say("{} has chosen to opt out of statistics and the trainer profile system.".format(trn[0]))
+		elif t_opt_out:
+			await self.bot.say("{} has chosen to opt out of statistics and the trainer profile system.".format(t_pogo))
 		else:
-			trnrlvl = c.execute('SELECT level, min_xp FROM levels WHERE min_xp<?', (trn[1],)).fetchall()[-1]
-			team = c.execute('SELECT name, leader, role, colour, logo FROM teams WHERE id=?', (trn[3],)).fetchone()
-			embed=discord.Embed(title=trn[0], timestamp=(datetime.datetime.fromtimestamp(trn[2], tz)), color=team[3])
-			embed.add_field(name='Name', value=trn[5] or 'Undisclosed')
-			embed.add_field(name='Team', value=team[0])
-			embed.add_field(name='Level', value=trnrlvl[0])
-			embed.add_field(name='XP', value=trn[1]-trnrlvl[1])
-			embed.set_thumbnail(url=team[4])
-			if trn[6] == 1:
+			l_level, l_min = c.execute('SELECT level, min_xp FROM levels WHERE min_xp<?', (t_xp,)).fetchall()[-1]
+			f_name, f_leader, f_mentionable, f_colour, f_logo = c.execute('SELECT name, leader, role, colour, logo FROM teams WHERE id=?', (t_team,)).fetchone()
+			embed=discord.Embed(title=t_pogo, timestamp=(datetime.datetime.fromtimestamp(t_time, tz)), color=f_colour)
+			embed.add_field(name='Name', value=t_name or 'Undisclosed')
+			embed.add_field(name='Team', value=f_name)
+			embed.add_field(name='Level', value=l_level)
+			embed.add_field(name='XP', value=t_xp-l_min)
+			embed.set_thumbnail(url=f_logo)
+			if t_cheat == 1:
 				embed.set_thumbnail(url='https://cdn.discordapp.com/attachments/341635533497434112/344984256633634818/C_SesKvyabCcQCNjEc1FJFe1EGpEuascVpHe_0e_DulewqS5nYtePystL4un5wgVFhIw300.png')
-				embed.add_field(name='Comments', value='{} is a known spoofer'.format(trn[0]))
+				embed.add_field(name='Comments', value='{} is a known spoofer'.format(t_pogo))
 			if goal:
 				embed.add_field(name='Daily goal completion', value=goal)
-			embed.set_footer(text="Total XP: "+str(trn[1]))
+			embed.set_footer(text="Total XP: "+str(t_xp))
 			await self.bot.say(embed=embed)	
 	
-	async def add_profile(self, discord, name, team, level, xp):
-		tteam = team.title()
-		if not (tteam in ['Valor','Mystic','Instinct', 'Teamless']):
+	async def addProfile(self, discord, name, team, level, xp):
+		if not (team in ['Valor','Mystic','Instinct', 'Teamless']):
 			await self.bot.say("{} isn't a valid team. Please ensure that you have used the command correctly.".format(tteam))
 			return
-		lvl = c.execute('SELECT level, min_xp FROM levels WHERE level=?', (level,)).fetchone()
-		teami = c.execute('SELECT id FROM teams WHERE name=?', (tteam,)).fetchone()
+		l_level, l_min = c.execute('SELECT level, min_xp FROM levels WHERE level=?', (level,)).fetchone()
+		f_id, = c.execute('SELECT id FROM teams WHERE name=?', (team,)).fetchone()
 		try:
-			c.execute("INSERT INTO trainers (pogo_name, discord_id, total_xp, last_updated, team) VALUES (?,?,?,?,?)",(name, discord, lvl[1]+int(xp), int(time.time()), teami[0]))
+			c.execute("INSERT INTO trainers (pogo_name, discord_id, total_xp, last_updated, team) VALUES (?,?,?,?,?)",(name, discord, l_min+int(xp), int(time.time()), f_id))
 		except sqlite3.IntegrityError:
 			await self.bot.say("Happy Error: Profile already exists. Just use the `updatexp`command :slightsmile:")
 		else:
@@ -84,23 +84,23 @@ class Profiles:
 	@commands.command(pass_context=True)
 	async def whois(self, ctx, name): #user lookup
 		await self.bot.send_typing(ctx.message.channel)
-		await self.profile_card(name, ctx.message.channel)
+		await self.profileCard(name, ctx.message.channel)
 
 	@commands.command(pass_context=True)
 	async def updatexp(self, ctx, xp): #updatexp - a command used for updating the total experience of a user
 		await self.bot.send_typing(ctx.message.channel)
-		oldxp = c.execute('SELECT pogo_name, total_xp, last_updated, goal FROM trainers WHERE discord_id=?', (ctx.message.author.id,)).fetchone()
-		if oldxp:
-			if int(oldxp[1]) > int(xp):
+		t_pogo, t_xp, t_time, t_goal = c.execute('SELECT pogo_name, total_xp, last_updated, goal FROM trainers WHERE discord_id=?', (ctx.message.author.id,)).fetchone()
+		if t_xp:
+			if int(t_xp) > int(xp):
 				await self.bot.say("Error: You're trying to set an your XP to a lower value. Please make sure you're using your Total XP at the bottom of your profile.")
 				return
-			c.execute("INSERT INTO xp_history (trainer, xp, time) VALUES (?,?,?)", (oldxp[0], oldxp[1], oldxp[2]))
+			c.execute("INSERT INTO xp_history (trainer, xp, time) VALUES (?,?,?)", (t_pogo, t_xp, t_time))
 			c.execute("UPDATE trainers SET total_xp=?, last_updated=? WHERE discord_id=?", (int(xp), int(time.time()), ctx.message.author.id))
 			trnr.commit()
-			if oldxp[3]:
-				await self.profile_card(oldxp[0], ctx.message.channel, goal='{}%'.format(str(await self.goal_daily(ctx.message.author.id))))
+			if t_goal:
+				await self.profileCard(t_pogo, ctx.message.channel, goal='{}%'.format(str(await self.goalDaily(ctx.message.author.id))))
 			else:
-				await self.profile_card(oldxp[0], ctx.message.channel)
+				await self.profileCard(t_pogo, ctx.message.channel)
 		else:
 			await self.bot.say(NOT_IN_SYSTEM)
 			return
@@ -108,11 +108,11 @@ class Profiles:
 	@commands.command(pass_context=True)
 	async def setname(self, ctx, *, name: str): #setname - a command used for to set your name on your profile
 		await self.bot.send_typing(ctx.message.channel)
-		profile = c.execute('SELECT pogo_name FROM trainers WHERE discord_id=?', (ctx.message.author.id,)).fetchone()
-		if profile:
+		t_pogo, = c.execute('SELECT pogo_name FROM trainers WHERE discord_id=?', (ctx.message.author.id,)).fetchone()
+		if t_pogo:
 			c.execute("UPDATE trainers SET real_name=? WHERE discord_id=?", (name, ctx.message.author.id))
 			trnr.commit()
-			await self.profile_card(profile[0], ctx.message.channel)
+			await self.profileCard(t_pogo, ctx.message.channel)
 		else:
 			await self.bot.say(NOT_IN_SYSTEM)
 			return
@@ -120,8 +120,8 @@ class Profiles:
 	@commands.command(pass_context=True)
 	async def setgoal(self, ctx, goal: int): #setgoal - a command used for to set your daily goal on your profile
 		await self.bot.send_typing(ctx.message.channel)
-		profile = c.execute('SELECT pogo_name FROM trainers WHERE discord_id=?', (ctx.message.author.id,)).fetchone()
-		if profile:
+		t_pogo, = c.execute('SELECT pogo_name FROM trainers WHERE discord_id=?', (ctx.message.author.id,)).fetchone()
+		if t_pogo:
 			c.execute("UPDATE trainers SET goal=? WHERE discord_id=?", (goal, ctx.message.author.id))
 			trnr.commit()
 			await self.bot.say("Your daily XP goal is set to {}.".format(goal))
@@ -136,16 +136,15 @@ class Profiles:
 	async def newprofile(self, ctx, mention, name, team, level, xp): #adding a user to the database
 		await self.bot.send_typing(ctx.message.channel)
 		mbr = ctx.message.mentions[0]
-		await self.add_profile(mbr.id, name, team, level, xp)
-		await self.profile_card(name, ctx.message.channel)
+		await self.addProfile(mbr.id, name, team.title(), level, xp)
+		await self.profileCard(name, ctx.message.channel)
 		
 	@commands.command(pass_context=True)
 	@checks.mod_or_permissions(assign_roles=True)
 	async def approve(self, ctx, mention, name, team, level, xp): #applies the correct roles to a user and adds the user to the database
 		await self.bot.send_typing(ctx.message.channel)
-		tteam = team.title()
-		if not (tteam in ['Valor','Mystic','Instinct', 'Teamless']):
-			await self.bot.say("{} isn't a valid team. Please ensure that you have used the command correctly.".format(tteam))
+		if not (team.title() in ['Valor','Mystic','Instinct', 'Teamless']):
+			await self.bot.say("{} isn't a valid team. Please ensure that you have used the command correctly.".format(team.title()))
 			return
 		mbr = ctx.message.mentions[0]
 		try:
@@ -153,20 +152,20 @@ class Profiles:
 		except discord.errors.Forbidden:
 			await self.bot.say("Error: I don't have permission to change nicknames. Aborted!")
 		else:
-			trnrrole = discord.utils.get(ctx.message.server.roles, name='Trainer')
-			tmrole = discord.utils.get(ctx.message.server.roles, name=tteam)
+			approved_mentionable = discord.utils.get(ctx.message.server.roles, name='Trainer')
+			team_mentionable = discord.utils.get(ctx.message.server.roles, name=team.title())
 			try:
-				await self.bot.add_roles(mbr, trnrrole)
-				if (tteam in ['Valor','Mystic','Instinct']):
+				await self.bot.add_roles(mbr, approved_mentionable)
+				if (team.title() in ['Valor','Mystic','Instinct']):
 					await self.bot.send_typing(ctx.message.channel)
-					await asyncio.sleep(2.5)
-					await self.bot.add_roles(mbr, tmrole)
+					await asyncio.sleep(2.5) #Waits for 2.5 seconds to pass to get around Discord rate limiting
+					await self.bot.add_roles(mbr, team_mentionable)
 			except discord.errors.Forbidden:
 				await self.bot.say("Error: I don't have permission to set roles. Aborted!")
 			else:
 				await self.bot.say("{} has been approved, super. They're probably super cool, be nice to them.".format(name))
-				await self.add_profile(mbr.id, name, team, level, xp)
-				await self.profile_card(name, ctx.message.channel) 
+				await self.addProfile(mbr.id, name, team.title(), level, xp)
+				await self.profileCard(name, ctx.message.channel) 
 		
 def setup(bot):
     bot.add_cog(Profiles(bot))


### PR DESCRIPTION
On servers with a `Minor` role, you can use the optional argument `Minor` after the XP on the `approve` command.
Added Spoofer setting into the `approve` and `newprofile` commands which set a user as a cheater/spoofer in the database command.

(Also, a bunch of readability updates and minor text fixes. All tested, all commands are still working.) 